### PR TITLE
Update Application folder path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A demo for learning [Rust](https://www.rust-lang.org).
 # Install
   - brew cask
 ```sh
-brew cask install tickeys && open ~/Applications/Tickeys.app
+brew cask install tickeys && open /Applications/Tickeys.app
 ```
   - or download the [dmg](https://github.com/yingDev/Tickeys/releases/download/0.5.0/Tickeys-0.5.0-yosemite.dmg)
 


### PR DESCRIPTION
It seems that the default Application folder path is `/Applications` but not `~/Applications`